### PR TITLE
Add missing declarations for functions in table

### DIFF
--- a/mach/proto/top/top.c
+++ b/mach/proto/top/top.c
@@ -40,6 +40,9 @@ static void oldinstr(instr_p);
 static bool op_separator(instr_p);
 static bool well_shaped(const char *);
 static bool is_letter(char);
+static int is_word_offset(char *s);
+static int is_loi8(char *s);
+static int is_sti8(char *s);
 
 static struct variable var[NRVARS+1];
 static struct variable ANY;  /* ANY symbol matching any instruction */


### PR DESCRIPTION
Fixes: 
https://github.com/andrastantos/cray-sim/issues/9#issuecomment-2524816173

```
gcc -c -o /tmp/ack-build/obj/plat/cos/...os/top_topgen -g -O0 -Wno-return-type -Iplat/cos 
FAILED: /tmp/ack-build/obj/plat/cos/top/main/top/top.o 
gcc -c -o /tmp/ack-build/obj/plat/cos/top/main/top/top.o mach/proto/top/top.c -I/tmp/ack-build/obj/plat/cos/top_topgen -g -O0 -Wno-return-type -Iplat/cos 
In file included from mach/proto/top/top.c:50:
mach/crayxmp/top/table: In function ‘check_constraint’:
mach/crayxmp/top/table:14:8: error: implicit declaration of function ‘is_word_offset’ [-Wimplicit-function-declaration]
   14 |    { is_word_offset(X) && is_loi8(Z) }
      |        ^~~~~~~~~~~~~~
mach/crayxmp/top/table:14:40: error: implicit declaration of function ‘is_loi8’ [-Wimplicit-function-declaration]
   14 |    { is_word_offset(X) && is_loi8(Z) }
      |                                        ^      
mach/crayxmp/top/table:23:40: error: implicit declaration of function ‘is_sti8’ [-Wimplicit-function-declaration]
   23 |    { is_word_offset(X) && is_sti8(Z) }
      |                                        ^      
[638/1274] rm -f /tmp/ack-build/obj/lang/cem/cemc...em/cemcom.ansi/cemcom/main/statement/statement.o 
ninja: build stopped: subcommand failed.
```